### PR TITLE
ci: exclude pip-compile'd files from renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -25,6 +25,7 @@
     enabled: true,
   },
   minimumReleaseAge: "7 days",
+  ignorePaths: ["requirements*.txt", "setup.cfg"],
   labels: ["kind/dependencies"],
   packageRules: [
     {


### PR DESCRIPTION
Fixes #46
Proof of Concept: https://github.com/JonasPammer/cookiecutter-pypackage/pull/116